### PR TITLE
Add styling to components

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -4,7 +4,6 @@ import ButtonPanel from './ButtonPanel';
 
 const App = () => (
   <div className="App">
-    <h1>React Calculator</h1>
     <Display result="0" />
     <ButtonPanel />
   </div>

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,22 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Button = ({ buttonName, color, wide }) => (
-  <button type="button" className={`button border ${wide} ${color}`}>
-    {buttonName}
-  </button>
-);
-
+const Button = ({ buttonName, color, wide }) => {
+  const twice = wide === true && 'wide';
+  return (
+    <button type="button" className={`button border ${twice} ${color}`}>
+      {buttonName}
+    </button>
+  );
+};
 Button.propTypes = {
   buttonName: PropTypes.string,
   color: PropTypes.string,
-  wide: PropTypes.string,
+  wide: PropTypes.bool,
 };
 
 Button.defaultProps = {
   buttonName: '',
-  color: '',
-  wide: '',
+  color: '#fe9291',
+  wide: false,
 };
 
 export default Button;

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,23 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Button = ({ buttonName, color, wide }) => {
-  const twice = wide === true && 'wide';
-  return (
-    <button type="button" className={`button border ${twice} ${color}`}>
-      {buttonName}
-    </button>
-  );
-};
+const Button = ({ buttonName, color, wide }) => (
+  <button type="button" className={`button border ${wide ? 'wide' : 'normalWidth'} ${color}`}>
+    {buttonName}
+  </button>
+);
+
 Button.propTypes = {
-  buttonName: PropTypes.string,
+  buttonName: PropTypes.string.isRequired,
   color: PropTypes.string,
   wide: PropTypes.bool,
 };
 
 Button.defaultProps = {
-  buttonName: '',
-  color: '#fe9291',
+  color: 'orange',
   wide: false,
 };
 

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,14 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Button = ({ buttonName }) => <button type="button">{buttonName}</button>;
+const Button = ({ buttonName, color, wide }) => (
+  <button type="button" className={`button border ${wide} ${color}`}>
+    {buttonName}
+  </button>
+);
 
 Button.propTypes = {
   buttonName: PropTypes.string,
+  color: PropTypes.string,
+  wide: PropTypes.string,
 };
 
 Button.defaultProps = {
   buttonName: '',
+  color: '',
+  wide: '',
 };
 
 export default Button;

--- a/src/components/ButtonPanel.js
+++ b/src/components/ButtonPanel.js
@@ -9,8 +9,7 @@ const ButtonPanel = () => {
     ['1', '2', '3', '+'],
     ['0', '.', '='],
   ];
-  const size = sign => sign === '0' && true;
-  const changeColor = (ind, length) => (length === ind + 1 ? 'color' : '');
+  const changeColor = (index, length) => (length === index + 1 ? 'pink' : undefined);
   return (
     <div className="buttonPanel">
       {symbols.map(symbol => (
@@ -19,7 +18,7 @@ const ButtonPanel = () => {
             <Button
               key={sign}
               color={changeColor(index, symbol.length)}
-              wide={size(sign)}
+              wide={sign === '0'}
               buttonName={sign}
             />
           ))}

--- a/src/components/ButtonPanel.js
+++ b/src/components/ButtonPanel.js
@@ -9,13 +9,19 @@ const ButtonPanel = () => {
     ['1', '2', '3', '+'],
     ['0', '.', '='],
   ];
-  const size = sign => (sign === '0' ? 'wide' : '');
+  const size = sign => sign === '0' && true;
+  const changeColor = (ind, length) => (length === ind + 1 ? 'color' : '');
   return (
     <div className="buttonPanel">
       {symbols.map(symbol => (
         <div className="row" key={symbol}>
-          {symbol.map(sign => (
-            <Button key={sign} color="color" wide={size(sign)} buttonName={sign} />
+          {symbol.map((sign, index) => (
+            <Button
+              key={sign}
+              color={changeColor(index, symbol.length)}
+              wide={size(sign)}
+              buttonName={sign}
+            />
           ))}
         </div>
       ))}

--- a/src/components/ButtonPanel.js
+++ b/src/components/ButtonPanel.js
@@ -9,13 +9,13 @@ const ButtonPanel = () => {
     ['1', '2', '3', '+'],
     ['0', '.', '='],
   ];
-
+  const size = sign => (sign === '0' ? 'wide' : '');
   return (
-    <div>
+    <div className="buttonPanel">
       {symbols.map(symbol => (
         <div className="row" key={symbol}>
           {symbol.map(sign => (
-            <Button key={sign} buttonName={sign} />
+            <Button key={sign} color="color" wide={size(sign)} buttonName={sign} />
           ))}
         </div>
       ))}

--- a/src/components/Display.js
+++ b/src/components/Display.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Display = ({ result }) => <div>{result}</div>;
+const Display = ({ result }) => <div className="display">{result}</div>;
 
 Display.propTypes = {
   result: PropTypes.string,

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -1,3 +1,2 @@
-/* Example of @import use
-This imports the `reset.css` file */
 @import './reset.css';
+@import './main.css';

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1,0 +1,58 @@
+.App {
+  width: 700px;
+  margin: 100px auto;
+}
+
+.App,
+.buttonPanel,
+.display {
+  display: flex;
+}
+
+.App,
+.buttonPanel {
+  display: flex;
+  flex-direction: column;
+}
+
+.display {
+  background-color: #808080;
+  align-items: center;
+  justify-content: flex-end;
+  color: #fff;
+  padding-right: 20px;
+  font-size: 2.5em;
+}
+
+.display,
+.row,
+.button {
+  font-family: inherit;
+  height: 100px;
+  font-weight: bold;
+}
+
+.row,
+.button {
+  font-size: 1.8em;
+}
+
+.button {
+  width: 25%;
+}
+
+.wide {
+  width: 50%;
+}
+
+.color {
+  background-color: orange;
+}
+
+.color:last-child {
+  background-color: #fe9291;
+}
+
+.color:hover {
+  opacity: 0.8;
+}

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -39,6 +39,11 @@
 
 .button {
   width: 25%;
+  background-color: orange;
+}
+
+.button:hover {
+  opacity: 0.8;
 }
 
 .wide {
@@ -46,13 +51,5 @@
 }
 
 .color {
-  background-color: orange;
-}
-
-.color:last-child {
   background-color: #fe9291;
-}
-
-.color:hover {
-  opacity: 0.8;
 }

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -37,9 +37,8 @@
   font-size: 1.8em;
 }
 
-.button {
+.normalWidth {
   width: 25%;
-  background-color: orange;
 }
 
 .button:hover {
@@ -50,6 +49,10 @@
   width: 50%;
 }
 
-.color {
+.orange {
+  background-color: orange;
+}
+
+.pink {
   background-color: #fe9291;
 }

--- a/src/css/reset.css
+++ b/src/css/reset.css
@@ -1,1 +1,289 @@
-/* Base styles */
+body {
+    font-family: "Comic sans MS", cursive, sans-serif;
+    background-color: #fff;
+    overflow-x: hidden;
+  }
+  
+  a,
+  abbr,
+  acronym,
+  address,
+  applet,
+  article,
+  aside,
+  audio,
+  b,
+  big,
+  blockquote,
+  button,
+  body,
+  canvas,
+  caption,
+  div,
+  dl,
+  fieldset,
+  figcaption,
+  figure,
+  footer,
+  form,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  header,
+  html,
+  i,
+  input,
+  iframe,
+  img,
+  ins,
+  kbd,
+  label,
+  legend,
+  li,
+  mark,
+  menu,
+  nav,
+  ol,
+  p,
+  picture,
+  section,
+  small,
+  span,
+  strike,
+  strong,
+  sub,
+  summary,
+  sup,
+  svg,
+  table,
+  tbody,
+  td,
+  tfoot,
+  th,
+  thead,
+  time,
+  tr,
+  tt,
+  u,
+  ul,
+  var,
+  video {
+    margin: 0;
+    padding: 0;
+    border: 0 none;
+    list-style: none outside none;
+    outline: 0 none;
+    box-sizing: border-box;
+  }
+  
+  a {
+    text-decoration: none;
+    color: inherit;
+  }
+  
+  a:hover {
+    color: inherit;
+    text-decoration: none;
+  }
+  
+  .ta_center {
+    text-align: center;
+  }
+  
+  .c_p {
+    cursor: pointer;
+  }
+  
+  .d_flex {
+    display: flex;
+  }
+  
+  .c_b {
+    color: rgb(0, 0, 0);
+  }
+  
+  .c_w {
+    color: rgb(255, 255, 255);
+  }
+  
+  .c_pw {
+    color: #f5f5f5;
+    text-shadow: rgb(197, 160, 91) 0 0 8px;
+  }
+  
+  .d_block {
+    display: block;
+  }
+  
+  .d_none {
+    display: none;
+  }
+  
+  .b_b {
+    border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+  }
+  
+  .border {
+    border: 1px solid rgba(0, 0, 0, 0.125);
+  }
+  
+  .border_none {
+    border: none;
+  }
+  
+  .bg_white {
+    background-color: #fff;
+  }
+  
+  .bbg {
+    background-color: rgba(0, 0, 0, 0.03);
+  }
+  
+  .no_p {
+    padding: 0;
+  }
+  
+  .no_m {
+    margin: 0;
+  }
+  
+  .p_10 {
+    padding: 10px;
+  }
+  
+  .br_30 {
+    border-radius: 30%;
+  }
+  
+  .m_10 {
+    margin: 10px;
+  }
+  
+  .mb_10 {
+    margin-bottom: 10px;
+  }
+  
+  .mt_10 {
+    margin-top: 10px;
+  }
+  
+  .ml_10 {
+    margin-left: 10px;
+  }
+  
+  .mr_10 {
+    margin-right: 10px;
+  }
+  
+  .pb_10 {
+    padding-bottom: 10px;
+  }
+  
+  .pt_10 {
+    padding-top: 10px;
+  }
+  
+  .bt_block {
+    border-top: 1px solid rgba(0, 0, 0, 0.125);
+  }
+  
+  .br_block {
+    border-right: 1px solid rgba(0, 0, 0, 0.125);
+  }
+  
+  .bl_block {
+    border-left: 1px solid rgba(0, 0, 0, 0.125);
+  }
+  
+  .bb_block {
+    border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+  }
+  
+  .bt_none {
+    border-top: none;
+  }
+  
+  .br_none {
+    border-right: none;
+  }
+  
+  .bl_none {
+    border-left: none;
+  }
+  
+  .bb_none {
+    border-bottom: none;
+  }
+  
+  .c_pink {
+    color: pink;
+  }
+  
+  .tt_upper {
+    text-transform: uppercase;
+  }
+  
+  .tt_cap {
+    text-transform: capitalize;
+  }
+  
+  .br_200 {
+    border-radius: 200px;
+  }
+  
+  .row {
+    margin-left: 0;
+    margin-right: 0;
+  }
+  
+  .o_h {
+    overflow: hidden;
+  }
+  
+  .w_full {
+    width: 100%;
+  }
+  
+  .l_0 {
+    left: 0;
+  }
+  
+  .b_0 {
+    bottom: 0;
+  }
+  
+  .r_0 {
+    right: 0;
+  }
+  
+  .t_0 {
+    top: 0;
+  }
+  
+  .td_none {
+    text-decoration: none;
+  }
+  
+  .font_12 {
+    font-size: 12px;
+  }
+  
+  .pos_rel {
+    position: relative;
+  }
+  
+  .pos_abs {
+    position: absolute;
+  }
+  
+  .d_r {
+    flex-direction: row;
+  }
+  
+  .d_c {
+    flex-direction: column;
+  }
+  


### PR DESCRIPTION
This PR does the following,

- Add flexbox to  `App`, `Display` and `ButtonPanel` components.

- Add Style to the `Display` component
   - to a gray background.
   - to have a height of 100px.
   - to present the result text to have white color and bold text.
   - to give padding to the result from the edges.
   - Align the result to the right.

- Add Style to the `ButtonPanel` component
   - to have a height of 100px.
   - to display `Button` groups horizontally.

-  Add Style to the `Button` component
  - Add `Button` width to take 25% of the container width, except for the button that represents the "0" (zero).
  - Centered the text in button and made its color to be black.
  - Add a border to buttons.

-  Pass "color" and "wide" props to the Button
  - The `color` prop is used to customize the color of the button.
  - The `wide` prop is used to set the width of the button

- [live demo](https://deploy-preview-3--adejam-react-calc.netlify.app/)